### PR TITLE
Support simultaneous ptx and lib building (multiple builds in a single builder)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Nicolas Patry <patry.nicolas@protonmail.com>"]
 name = "bindgen_cuda"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = """
 Bindgen like interface to build cuda kernels to interact with within Rust.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Nicolas Patry <patry.nicolas@protonmail.com>"]
 name = "bindgen_cuda"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = """
 Bindgen like interface to build cuda kernels to interact with within Rust.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,14 @@ fn default_include() -> Option<Vec<PathBuf>> {
 }
 
 impl Builder {
+    /// Force to use a given compute capability
+    pub fn set_compute_cap(&mut self, cap: usize) {
+        self.compute_cap = Some(cap);
+    }
+
+    pub fn get_compute_cap(&self) -> Option<usize> {
+        self.compute_cap
+    }
     /// Setup the kernel paths. All path must be set at once and be valid files.
     /// ```no_run
     /// let builder = bindgen_cuda::Builder::default().kernel_paths(vec!["src/mykernel.cu"]);


### PR DESCRIPTION
The current version does not support multiple builder instances and a build instance cannot be used for another build (as also mentioned in #2 ), I have fixed this by making the builder reusable, e.g., building ptx after lib building.

The tested use case:

``` rust
fn main() {
    println!("cargo:rerun-if-changed=build.rs");
    println!("cargo:rerun-if-changed=src/attention.cu");
    println!("cargo:rerun-if-changed=src/copy_blocks_kernel.cu");
    println!("cargo:rerun-if-changed=src/reshape_and_cache_kernel.cu");
    println!("cargo:rerun-if-changed=src/rotary_embedding_kernel.cu");
    let builder = bindgen_cuda::Builder::default();
    println!("cargo:info={builder:?}");
    builder.build_lib("libattention.a");

    let bindings = builder.build_ptx().unwrap();
    bindings.write("src/lib.rs").unwrap();

    println!("cargo:rustc-link-lib=attention"); 
}

```