### PR TITLE
Look up msvc env vars using `cc`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ documentation = "https://docs.rs/bindgen_cuda/"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+cc = "1.1.0"
 glob = "0.3.1"
 num_cpus = "1.16.0"
 rayon = "1.8.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -544,7 +544,7 @@ fn compute_cap() -> Result<usize, Error> {
     Ok(compute_cap)
 }
 
-/// Returns an iteartor over the environment variables needed to run the MSVC toolchain.
+/// Returns an iterator over the environment variables needed to run the MSVC toolchain.
 /// Use these when starting processes to make us behave as if called from a VS developer command prompt.
 /// Returns an empty iterator if not msvc
 fn msvc_env() -> impl Iterator<Item = (&'static OsStr, &'static OsStr)> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -551,9 +551,7 @@ fn msvc_env() -> impl Iterator<Item = (&'static OsStr, &'static OsStr)> {
     static MEMOIZED: OnceLock<Vec<(OsString, OsString)>> = OnceLock::new();
     MEMOIZED
         .get_or_init(|| {
-            if !cfg!(target_env = "msvc") {
-                return Vec::new();
-            }
+            // this returns None if not msvc
             let cl_tool = cc::windows_registry::find_tool(
                 &std::env::var("TARGET").expect("TARGET env var"),
                 "cl.exe",


### PR DESCRIPTION
Allows us to use this on windows without running through a visual studio developer prompt.

Should fix https://github.com/huggingface/candle/issues/2241