### PR TITLE
fix: Improve error message for missing `nvidia-smi`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -486,7 +486,7 @@ fn compute_cap() -> Result<usize, Error> {
                 .arg("--query-gpu=compute_cap")
                 .arg("--format=csv")
                 .output()
-                .expect("`nvidia-smi` failed. Ensure that you have CUDA installed and that `nvidia-smi` is in your PATH.");
+                .expect("`nvidia-smi` failed. Ensure that you have CUDA installed and that `nvidia-smi` is in your PATH or alternatively set the CUDA_COMPUTE_CAP environment variable.");
         let out = std::str::from_utf8(&out.stdout).expect("stdout is not a utf8 string");
         let mut lines = out.lines();
         assert_eq!(lines.next().expect("missing line in stdout"), "compute_cap");


### PR DESCRIPTION
When trying to build without a gpu, the error message given by bindgen_cuda does not indicate, that you can use bindgen_cuda without a gpu; leading to some confusion, like https://github.com/Narsil/bindgen_cuda/issues/4.
As a solution I'd suggest hinting at the fact by changing the error message