### PR TITLE
Capture extra args as Vec<String>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -459,13 +459,8 @@ fn cuda_include_dir() -> Option<PathBuf> {
 
     println!("cargo:info={roots:?}");
 
-    #[allow(unused)]
     let roots = roots.into_iter().map(Into::<PathBuf>::into);
 
-    #[cfg(feature = "ci-check")]
-    let root: PathBuf = "ci".into();
-
-    #[cfg(not(feature = "ci-check"))]
     env_vars
         .chain(roots)
         .find(|path| path.join("include").join("cuda.h").is_file())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub struct Builder {
     include_paths: Vec<PathBuf>,
     compute_cap: Option<usize>,
     out_dir: PathBuf,
-    extra_args: Vec<&'static str>,
+    extra_args: Vec<String>,
 }
 
 impl Default for Builder {
@@ -163,8 +163,8 @@ impl Builder {
     /// ```no_run
     /// let builder = bindgen_cuda::Builder::default().arg("--expt-relaxed-constexpr");
     /// ```
-    pub fn arg(mut self, arg: &'static str) -> Self {
-        self.extra_args.push(arg);
+    pub fn arg<S: AsRef<str>>(mut self, arg: S) -> Self {
+        self.extra_args.push(arg.as_ref().to_string());
         self
     }
 


### PR DESCRIPTION
There is some merit to using `&'static str`, but it doesn't actually prevent bad usage as you could do something like `Box::leak(String::new("my-string").into_boxed_str())`.
Incidentally if you _need_ to add an extra arg that is not static then the `Box::leak` approach is also the solution to get around this restriction. So imo good ol' `String` is a better choice.