### PR TITLE
Add compute_cap builder method and fix multiple Rayon init

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ documentation = "https://docs.rs/bindgen_cuda/"
 glob = "0.3.1"
 num_cpus = "1.16.0"
 rayon = "1.8.0"
+
+[features]
+ci-check = []


### PR DESCRIPTION
This PR adds a chainable method for manually setting the compute capability and adds prevention of multiple Rayon init.