### PR TITLE
Handle compute capability with letter at end

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -491,9 +491,13 @@ fn compute_cap() -> Result<usize, Error> {
     // Try to parse compute caps from env
     let compute_cap = if let Ok(compute_cap_str) = std::env::var("CUDA_COMPUTE_CAP") {
         println!("cargo:rustc-env=CUDA_COMPUTE_CAP={compute_cap_str}");
-        compute_cap_str
-            .parse::<usize>()
-            .expect("Could not parse code")
+        match compute_cap_str.parse::<usize>() {
+            Ok(c) => c,
+            // Handle letter-suffixed compute cap such as 121a/f
+            Err(_) => compute_cap_str[..compute_cap_str.len() - 1]
+                .parse::<usize>()
+                .expect("Could not parse code")
+        }
     } else {
         // Use nvidia-smi to get the current compute cap
         let out = std::process::Command::new("nvidia-smi")
@@ -508,8 +512,13 @@ fn compute_cap() -> Result<usize, Error> {
             .next()
             .expect("missing line in stdout")
             .replace('.', "");
-        let cap = cap.parse::<usize>().expect("cannot parse as int {cap}");
         println!("cargo:rustc-env=CUDA_COMPUTE_CAP={cap}");
+        let cap = match cap.parse::<usize>() {
+            Ok(c) => c,
+            Err(_) => compute_cap_str[..compute_cap_str.len() - 1]
+                .parse::<usize>()
+                .expect("Could not parse as int {cap}")
+        }
         cap
     };
 


### PR DESCRIPTION
Cutlass needs to know about SM120a to properly build certain code such sa block-scaled MMA and FP4 related components ( https://github.com/NVIDIA/cutlass/issues/2820
https://github.com/pytorch/pytorch/issues/172807
).

Attempt to remedy this by allowing the parser to detect the digits of the compute cap returned by smi or taken from the env when the default parse fails by dropping the last char of the parsed string. Record the provided cap in the environment variable target to pass it downstream but retain the usize datatype for this library for now.