### PR TITLE
Fix CUDA compilation with Windows MSVC

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,6 +256,8 @@ impl Builder {
             .par_iter()
             .map(|(cu_file, obj_file)| {
                 let mut command = std::process::Command::new("nvcc");
+                #[cfg(windows)]
+                command.args(["-Xcompiler", "/Zc:preprocessor", "-DNOGDI"]);
                 command
                     .arg(format!("--gpu-architecture=sm_{compute_cap}"))
                     .arg("-c")
@@ -375,6 +377,8 @@ impl Builder {
                     None
                 } else {
                     let mut command = std::process::Command::new("nvcc");
+                    #[cfg(windows)]
+                    command.args(["-Xcompiler", "/Zc:preprocessor", "-DNOGDI"]);
                     command.arg(format!("--gpu-architecture=sm_{compute_cap}"))
                         .arg("--ptx")
                         .args(["--default-stream", "per-thread"])


### PR DESCRIPTION
Add Windows-specific nvcc flags to fix the build:

- `-Xcompiler /Zc:preprocessor`: Enables MSVC's standards-conformant C/C++ preprocessor, which correctly handles complex macro patterns in Windows SDK headers like oaidl.h.

- `-DNOGDI`: Excludes GDI definitions from Windows headers, preventing wingdi.h's CC_MSCPASCAL macro from conflicting with the enum of the same name in oaidl.h.