### PR TITLE
Add multi-gencode support for fat binary builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ documentation = "https://docs.rs/bindgen_cuda/"
 
 [dependencies]
 glob = "0.3.1"
+libloading = "0.8"
 num_cpus = "1.16.0"
 rayon = "1.8.0"
 


### PR DESCRIPTION
- Add compute_caps() builder method for multiple architecture targets
- Add CUDA_COMPUTE_CAPS env var (plural) with priority over CUDA_COMPUTE_CAP
- Support CUDA_COMPUTE_CAPS=all to expand to default set (75,80,86,89,90)
- build_lib() uses -gencode flags when multiple CCs configured
- build_ptx() compiles for lowest CC (forward-compatible via JIT)
- Validate all requested CCs against nvcc --list-gpu-code
- Expose resolved CC list via cargo:rustc-env=CUDA_COMPUTE_CAPS
- Add unit tests for gencode flag generation
- Full backward compatibility when new env vars are unset